### PR TITLE
Escape quote characters (")

### DIFF
--- a/automations/extract.py
+++ b/automations/extract.py
@@ -44,6 +44,7 @@ def main():
                 linelist = source.readlines()
                 for line in linelist:
                     os.system("echo line is:  " + line + "echo \n")
+                    line = line.replace(r'"', r'\"')
                     temp.write('{0}{1}{2}{3}'.format(ftag, line.strip("\n"), btag,
                             "\n"))
 


### PR DESCRIPTION
Quotes need to be escaped before passing the tags to xgettext, otherwise the string will be cut when pushed to translate.mycroft.ai

This results in the following block for email.body.dialog in the *fallback-wolfram-alpha* skill:
```po
#: tags/skills/fallback-wolfram-alpha.mycroftai/email.body.dialog:1
msgid ""
"You asked <br/><ul><tt>'{{query}}'</tt></ul><br/> and were told <br/"
"><ul><tt>'{{answer}}'</tt></ul><P> For more details and the information "
"sources used to generate the answer visit:<br/><a href=\"http://www."
"wolframalpha.com/input/?i={{url_query}}\">www.wolframalpha.com</a>"
msgstr ""
```