### PR TITLE
Bugfix/cron path error

### DIFF
--- a/automations/extract.py
+++ b/automations/extract.py
@@ -10,26 +10,30 @@ ftag = "_(\""
 btag = "\")"
 
 def main():
-
+    # add old dialog/en-us, vocab/en-us style paths
     oldstylepaths = glob("mycroft-skills/**/en-us/**.*", recursive=True)
-    print("\n pathlist is: " )  
-    for path in oldstylepaths:
-        print (path) 
 
     # add locale path to the pathlist
     newstylepaths = glob("mycroft-skills/locale/en-us/**.*", recursive=True)
-    print("\n pathlist is: " )  
-    for path in newstylepaths:
-        print (path)
 
     combinedpaths = oldstylepaths + newstylepaths
+    print("\n pathlist is: " )
+    for path in combinedpaths:
+        print (path)
 
+    # print a count of the paths to aid in debugging
+    print("\n there were",  sum('locale/' in s for s in combinedpaths), "LOCALE paths added")
+    print("\n there were", sum('dialog/' in s for s in combinedpaths), "DIALOG paths added")
+    print("\n there were", sum('vocab/' in s for s in combinedpaths) , "VOCAB paths added")
+    print("\n there were", sum('mycroft-skills/' in s for s in combinedpaths), " paths added in total")
 
+    # create the tags and pots directories
     if not os.path.exists('tags'):
         os.mkdir('tags')
 
     if not os.path.exists('pots'):
         os.mkdir('pots')
+
     for path in combinedpaths:
         print(" ======================================== \n")
         print(" Began tagging the path " + path)
@@ -46,14 +50,16 @@ def main():
         tagpath = os.path.join('tags', skill)
         print("\n tagpath is:  " + tagpath)
 
-
+        # write out the files to a `tags` dir
         with open(path, 'r') as source:
             tagdir = os.path.join('tags', skill)
+            print("\n tagdir is:  " + tagdir)
             if not os.path.exists(tagdir):
                 os.makedirs(tagdir)
             with open(os.path.join(tagdir,file), 'w') as temp:
                 linelist = source.readlines()
                 for line in linelist:
+                    print("line before replace() is:  " + line)
                     line = line.replace(r'"', r'\"')
                     print("line is:  " + line)
                     temp.write('{0}{1}{2}{3}'.format(ftag, line.strip("\n"), btag,
@@ -66,11 +72,12 @@ def main():
         if not os.path.exists('pots/' + dir):
             os.makedirs('pots/' + dir)
             print("\n creating dir: " + ('pots/' + dir))
-        gtxtcommand = "xgettext --keyword=_ --language=Python --add-comments " + \
+        gtxtcommand = "xgettext --from-code --keyword=_ --language=Python --add-comments " + \
                     "--output='pots/" + dir +".pot' tags/" + dir + "/*.*"
 
         print("\n gtxtcommand is:  " + gtxtcommand + "\n")
-        os.system(gtxtcommand)
+        exitstatus = os.system(gtxtcommand)
+        print("\n exit status: ", exitstatus, "\n")
         print("\n created file: " +  'pots/' + dir + '.pot')
 
 if __name__ == '__main__':

--- a/automations/extract.py
+++ b/automations/extract.py
@@ -72,7 +72,7 @@ def main():
         if not os.path.exists('pots/' + dir):
             os.makedirs('pots/' + dir)
             print("\n creating dir: " + ('pots/' + dir))
-        gtxtcommand = "xgettext --from-code --keyword=_ --language=Python --add-comments " + \
+        gtxtcommand = "xgettext --from-code=utf-8 --keyword=_ --language=Python --add-comments " + \
                     "--output='pots/" + dir +".pot' tags/" + dir + "/*.*"
 
         print("\n gtxtcommand is:  " + gtxtcommand + "\n")

--- a/automations/extract.py
+++ b/automations/extract.py
@@ -11,21 +11,17 @@ btag = "\")"
 
 def main():
     # add old dialog/en-us, vocab/en-us style paths
-    oldstylepaths = glob("mycroft-skills/**/en-us/**.*", recursive=True)
+    paths = glob("mycroft-skills/**/en-us/**.*", recursive=True)
 
-    # add locale path to the pathlist
-    newstylepaths = glob("mycroft-skills/locale/en-us/**.*", recursive=True)
-
-    combinedpaths = oldstylepaths + newstylepaths
     print("\n pathlist is: " )
-    for path in combinedpaths:
+    for path in paths:
         print (path)
 
     # print a count of the paths to aid in debugging
-    print("\n there were",  sum('locale/' in s for s in combinedpaths), "LOCALE paths added")
-    print("\n there were", sum('dialog/' in s for s in combinedpaths), "DIALOG paths added")
-    print("\n there were", sum('vocab/' in s for s in combinedpaths) , "VOCAB paths added")
-    print("\n there were", sum('mycroft-skills/' in s for s in combinedpaths), " paths added in total")
+    print("\n there were",  sum('locale/' in s for s in paths), "LOCALE paths added")
+    print("\n there were", sum('dialog/' in s for s in paths), "DIALOG paths added")
+    print("\n there were", sum('vocab/' in s for s in paths) , "VOCAB paths added")
+    print("\n there were", sum('mycroft-skills/' in s for s in paths), " paths added in total")
 
     # create the tags and pots directories
     if not os.path.exists('tags'):
@@ -34,7 +30,7 @@ def main():
     if not os.path.exists('pots'):
         os.mkdir('pots')
 
-    for path in combinedpaths:
+    for path in paths:
         print(" ======================================== \n")
         print(" Began tagging the path " + path)
 

--- a/automations/extract.py
+++ b/automations/extract.py
@@ -11,14 +11,26 @@ btag = "\")"
 
 def main():
 
-    pathlist = glob("mycroft-skills/**/en-us/**.*", recursive=True)
+    oldstylepaths = glob("mycroft-skills/**/en-us/**.*", recursive=True)
+    print("\n pathlist is: " )  
+    for path in oldstylepaths:
+        print (path) 
+
+    # add locale path to the pathlist
+    newstylepaths = glob("mycroft-skills/locale/en-us/**.*", recursive=True)
+    print("\n pathlist is: " )  
+    for path in newstylepaths:
+        print (path)
+
+    combinedpaths = oldstylepaths + newstylepaths
+
 
     if not os.path.exists('tags'):
         os.mkdir('tags')
 
     if not os.path.exists('pots'):
         os.mkdir('pots')
-    for path in pathlist:
+    for path in combinedpaths:
         print(" ======================================== \n")
         print(" Began tagging the path " + path)
 

--- a/automations/importer.sh
+++ b/automations/importer.sh
@@ -43,13 +43,18 @@ cd ../
 # the locally cloned mycroft-skills repo, may need to update that
 python3 extract.py
 
-# copy the contents of the pots directory to the Pootle translations dir
-cp -r pots/* $POOTLE_TRANSLATION_DIRECTORY/
 
 # Activate the Pootle virtual environment
 cd /var/www/pootle/
 echo "pwd is: " $PWD
 source env/bin/activate
+
+# Update from database to filesystem
+pootle sync_stores --project=mycroft-skills
+
+
+# copy the contents of the pots directory to the Pootle translations dir
+cp -r $AUTOMATIONS_DIR/pots/* $POOTLE_TRANSLATION_DIRECTORY/
 
 # Update from filesystem to database
 pootle update_stores --project=mycroft-skills
@@ -142,10 +147,10 @@ cd $AUTOMATIONS_DIR
 echo "pwd is: " $PWD
 echo "now cleaning up directories that were created..."
 echo "removing pots directory..."
-#rm -R pots
+rm -R pots
 echo "removing tags directory..."
-#rm -R tags
+rm -R tags
 echo "removing " $LOCAL_REPO_NAME
-#rm -R $LOCAL_REPO_NAME
+rm -R $LOCAL_REPO_NAME
 
 echo "end script" 

--- a/automations/importer.sh
+++ b/automations/importer.sh
@@ -22,13 +22,14 @@
 # Setup variables
 MYCROFT_SKILLS_REPO=https://github.com/MycroftAI/mycroft-skills.git
 POOTLE_TRANSLATION_DIRECTORY=/var/www/pootle/env/lib/python2.7/site-packages/pootle/translations/mycroft-skills
-LOCAL_REPO_NAME=~/mycroft-translate/automations/mycroft-skills
-AUTOMATIONS_DIR=~/mycroft-translate/automations
+LOCAL_REPO_NAME=/root/mycroft-translate/automations/mycroft-skills
+AUTOMATIONS_DIR=/root/mycroft-translate/automations
 
 # check to see that the  xgettext utility is available, abort if not
 command -v xgettext >/dev/null 2>&1 || { echo >&2 "I require gettext but it's not installed.  You need to run `sudo apt-get install gettext`. Aborting."; exit 1;} 
 
-# echo "MYCROFT_SKILLS_REPO is " $MYCROFT_SKILLS_REPO
+echo "MYCROFT_SKILLS_REPO is " $MYCROFT_SKILLS_REPO
+echo "LOCAL_REPO_NAME is " $LOCAL_REPO_NAME
 
 # Clone the latest `mycroft-skills` repo
 # and import all the gitmodules
@@ -40,7 +41,7 @@ cd ../
 # Run the extract.py script
 # @TODO I'm fairly sure this script assumes the name of
 # the locally cloned mycroft-skills repo, may need to update that
-./extract.py
+python3 extract.py
 
 # copy the contents of the pots directory to the Pootle translations dir
 cp -r pots/* $POOTLE_TRANSLATION_DIRECTORY/
@@ -68,6 +69,7 @@ cd $POOTLE_TRANSLATION_DIRECTORY/
 LANGUAGE_LIST="$(pootle list_languages)"
 
 echo "getting list of languages ..."
+echo $LANGUAGE_LIST
 
 i=0
 for LANGUAGE in $LANGUAGE_LIST
@@ -81,9 +83,10 @@ echo "there are " $i "languages"
 
 cd $POOTLE_TRANSLATION_DIRECTORY
 
-SKILL_LIST="$(ls | grep ".pot" | grep -v spotify)"
+SKILL_LIST="$(ls | grep ".pot$" )"
 
 echo "getting list of skills ..." 
+echo $SKILL_LIST
 
 j=0
 for SKILL in $SKILL_LIST
@@ -139,10 +142,10 @@ cd $AUTOMATIONS_DIR
 echo "pwd is: " $PWD
 echo "now cleaning up directories that were created..."
 echo "removing pots directory..."
-rm -R pots
+#rm -R pots
 echo "removing tags directory..."
-rm -R tags
+#rm -R tags
 echo "removing " $LOCAL_REPO_NAME
-rm -R $LOCAL_REPO_NAME
+#rm -R $LOCAL_REPO_NAME
 
 echo "end script" 

--- a/cronjobs/pootle-importer
+++ b/cronjobs/pootle-importer
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # This shell script sits in cron.daily
 # and wraps the importer.sh in a mail hander
 

--- a/cronjobs/pootle-importer
+++ b/cronjobs/pootle-importer
@@ -9,7 +9,7 @@ MAILTO=translate-admin@mycroft.ai
 set -e
 
 # output to a log file and if there are errors, send email
-if ! ~/mycroft-translate/automations/importer.sh 2>&1 > /tmp/pootle-importer.log; then
+if ! /root/mycroft-translate/automations/importer.sh 2>&1 > /tmp/pootle-importer.log; then
 	#send email
 	(
 		echo "To:$MAILTO"
@@ -17,6 +17,7 @@ if ! ~/mycroft-translate/automations/importer.sh 2>&1 > /tmp/pootle-importer.log
 		echo "MIME-Version: 1.0"
 		echo "Content-Type: text/plain"
 		echo cat /tmp/pootle-importer.log
+		echo "\nHOST: " $(hostname)
 	) | sendmail -oi $MAILTO
 
 fi


### PR DESCRIPTION
Someone forgot her shebang line because she hasn't had enough coffee today ...
This was causing `cron` to fail with 
```
/etc/cron.hourly/pootle-importer:
run-parts: failed to exec /etc/cron.hourly/pootle-importer: Exec format error
run-parts: /etc/cron.hourly/pootle-importer exited with return code 1

```

`cron` has run successfully since this was fixed