### PR TITLE
19.02 change

### DIFF
--- a/automations/extract/generate_prs.py
+++ b/automations/extract/generate_prs.py
@@ -26,7 +26,7 @@ from requests import get
 import polib
 from github_actions import get_work_repos, create_work_dir, create_or_edit_pr
 
-DEFAULT_BRANCH = '18.08'
+DEFAULT_BRANCH = '19.02'
 SKILLS_URL = ('https://raw.githubusercontent.com/MycroftAI/mycroft-skills/'
               '{}/.gitmodules')
 
@@ -132,7 +132,7 @@ pootle_langs = {
 
 def main():
     skill_repos = get_skill_repos()
-    
+
     for skill in skill_repos:
         # Get repo information
         skill_url = skill_repos[skill]


### PR DESCRIPTION
It feels like there should be more changes required however the version number seems to be hard coded in only one place `generate_prs.py`.

I've verified that Steve's recent [changes to mycroft-configuration](https://github.com/MycroftAI/skill-configuration/commit/4c035f4e1bbd0d0895adedc183a5be39adddc8b0) have already been [imported into Pootle](https://translate.mycroft.ai/en/mycroft-skills/translate/skill-configuration-en.po#offset=18&unit=262630). 

Also verified that `get_skill_repos(branch)` correctly generates the dictionary of skill repo's on translate-test. 

Anything else I'm not thinking of?